### PR TITLE
Switch to cson-safe for parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "underscore-plus": "1.x",
-    "coffee-script": "~1.7.0",
+    "cson-safe": "~0.1.0",
     "optimist": "~0.4.0",
     "fs-plus": "2.x"
   },

--- a/spec/cson-spec.coffee
+++ b/spec/cson-spec.coffee
@@ -97,8 +97,8 @@ describe "CSON", ->
           f: true
 
       cson = CSON.stringify(object)
-      CoffeeScript = require 'coffee-script'
-      evaledObject = CoffeeScript.eval(cson, bare: true)
+      CSONParser = require 'cson-safe'
+      evaledObject = CSONParser.parse(cson)
       expect(evaledObject).toEqual object
 
   describe ".isObjectPath(objectPath)", ->
@@ -178,32 +178,32 @@ describe "CSON", ->
         samplePath = path.join(__dirname, 'fixtures', 'sample.cson')
         cacheDir = temp.mkdirSync('cache-dir')
         CSON.setCacheDir(cacheDir)
-        CoffeeScript = require 'coffee-script'
-        spyOn(CoffeeScript, 'eval').andCallThrough()
+        CSONParser = require 'cson-safe'
+        spyOn(CSONParser, 'parse').andCallThrough()
 
         expect(CSON.readFileSync(samplePath)).toEqual {a: 1, b: c: true}
-        expect(CoffeeScript.eval.callCount).toBe 1
-        CoffeeScript.eval.reset()
+        expect(CSONParser.parse.callCount).toBe 1
+        CSONParser.parse.reset()
         expect(CSON.readFileSync(samplePath)).toEqual {a: 1, b: c: true}
-        expect(CoffeeScript.eval.callCount).toBe 0
+        expect(CSONParser.parse.callCount).toBe 0
 
     describe "asynchronous reads", ->
       it "caches the contents of the compiled CSON files", ->
         samplePath = path.join(__dirname, 'fixtures', 'sample.cson')
         cacheDir = temp.mkdirSync('cache-dir')
         CSON.setCacheDir(cacheDir)
-        CoffeeScript = require 'coffee-script'
-        spyOn(CoffeeScript, 'eval').andCallThrough()
+        CSONParser = require 'cson-safe'
+        spyOn(CSONParser, 'parse').andCallThrough()
 
         sample = null
         CSON.readFile samplePath, (error, object) -> sample = object
         waitsFor -> sample?
         runs ->
           expect(sample).toEqual {a: 1, b: c: true}
-          expect(CoffeeScript.eval.callCount).toBe 1
-          CoffeeScript.eval.reset()
+          expect(CSONParser.parse.callCount).toBe 1
+          CSONParser.parse.reset()
           sample = null
           CSON.readFile samplePath, (error, object) -> sample = object
         waitsFor -> sample?
         runs ->
-          expect(CoffeeScript.eval.callCount).toBe 0
+          expect(CSONParser.parse.callCount).toBe 0

--- a/src/cson.coffee
+++ b/src/cson.coffee
@@ -3,7 +3,7 @@ path = require 'path'
 
 _ = require 'underscore-plus'
 fs = require 'fs-plus'
-CoffeeScript = null
+CSONParser = null
 
 multiplyString = (string, n) -> new Array(1 + n).join(string)
 
@@ -92,8 +92,8 @@ writeCacheFile = (cachePath, object) ->
 
 parseObject = (objectPath, contents) ->
   if path.extname(objectPath) is '.cson'
-    CoffeeScript ?= require 'coffee-script'
-    CoffeeScript.eval(contents, {bare: true, sandbox: true})
+    CSONParser ?= require 'cson-safe'
+    CSONParser.parse(contents)
   else
     JSON.parse(contents)
 


### PR DESCRIPTION
As discussed in [an issue on a different project](https://github.com/bevry/cson/issues/33), using eval for config files is a suboptimal solution. What I'm suggesting here is an approach based on walking the CoffeeScript AST instead. The parser allows for statically evaluated arithmetic expressions (e.g. `myFlag: 1 << 3`). If that's a concern, I'd be happy to make it optional. I chose to implement the parsing in its own module since I think that having a minimalistic parsing library that just offers the `JSON.{parse,stringify}` interface could be valuable to people.

More information about the behavior of the parser:
- [parse test in cson-safe](https://github.com/groupon/cson-safe/blob/master/test/parse.coffee)
- [Error message](https://github.com/groupon/cson-safe/blob/37912fc799990c839b5e686013ed7976915c902d/test/parse.coffee#L82)

See also: bevry/cson#34
