### PR TITLE
readFile error message includes path on parse error

### DIFF
--- a/spec/cson-spec.coffee
+++ b/spec/cson-spec.coffee
@@ -298,6 +298,7 @@ describe "CSON", ->
     it "calls back with an error for invalid files", ->
       callback = (error, content) ->
         expect(error).not.toBeNull()
+        expect(error.path).toEqual path.join(__dirname, 'fixtures', 'invalid.cson')
         expect(error.message).toContain path.join(__dirname, 'fixtures', 'invalid.cson')
         expect(content).toBeUndefined()
 

--- a/spec/cson-spec.coffee
+++ b/spec/cson-spec.coffee
@@ -298,6 +298,7 @@ describe "CSON", ->
     it "calls back with an error for invalid files", ->
       callback = (error, content) ->
         expect(error).not.toBeNull()
+        expect(error.message).toContain path.join(__dirname, 'fixtures', 'invalid.cson')
         expect(content).toBeUndefined()
 
       readFile(path.join(__dirname, 'fixtures', 'invalid.cson'), callback)

--- a/src/cson.coffee
+++ b/src/cson.coffee
@@ -60,6 +60,7 @@ parseContents = (objectPath, cachePath, contents, callback) ->
   try
     object = parseObject(objectPath, contents)
   catch parseError
+    parseError.path = objectPath
     parseError.message = "#{objectPath}: #{parseError.message}"
     callback?(parseError)
     return

--- a/src/cson.coffee
+++ b/src/cson.coffee
@@ -60,6 +60,7 @@ parseContents = (objectPath, cachePath, contents, callback) ->
   try
     object = parseObject(objectPath, contents)
   catch parseError
+    parseError.message = "#{objectPath}: #{parseError.message}"
     callback?(parseError)
     return
 


### PR DESCRIPTION
If you could be parsing many different cson files, this is very useful in identifying which file has the parse error.