### PR TITLE
Upgrade cson-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "CoffeeScript"
   ],
   "dependencies": {
-    "cson-parser": "1.0.9",
+    "cson-parser": "^1.3.0",
     "fs-plus": "^3.0.0",
     "optimist": "~0.4.0"
   },


### PR DESCRIPTION
Allows CSON regex fields to be converted to equivalent strings in JSON among other cson-parser improvements

Some history of trying to make this update:
 - #17: closed for some reason. It affected the version number, so I'm just going to open a new PR
 - 278887d pinned cson-parser at 1.0.9 but without further clarification why. Upgrading to ^1.3.0 still passes all tests and I don't see any functionality being removed in cson-parer's [changelog](https://github.com/groupon/cson-parser/blob/master/CHANGELOG.md)